### PR TITLE
Fix "Menu Course" translation

### DIFF
--- a/html/appLms/views/lomanager/show.html.twig
+++ b/html/appLms/views/lomanager/show.html.twig
@@ -1,5 +1,5 @@
 <div class="page-header">
-    <h1>{{ Lang_translate('menu_course', '_STORAGE') }}</h1>
+    <h1>{{ Lang_translate('_MENU_COURSE', 'storage') }}</h1>
 </div>
 
 <div class="std_block">


### PR DESCRIPTION
"Menu Course" title translation on Teacher Area wasn't being translated