### PR TITLE
Fix radio text alignment

### DIFF
--- a/html/appLms/modules/test/test.php
+++ b/html/appLms/modules/test/test.php
@@ -935,7 +935,7 @@ function defmodality()
     $GLOBALS['page']->add(
         Form::openFormLine()
             . Form::getInputRadio('order_type_random_quest', 'order_type', 2, $order_type == 2, '')
-            . '<label for="order_type_random_quest">' . $lang->def('_ORDER_TYPE_RANDOM') . '</label> - '
+            . ' <label for="order_type_random_quest">' . $lang->def('_ORDER_TYPE_RANDOM') . '</label> - '
             . '<label for="question_random_number">'
             . str_replace('[tot_quest]', $tot_quest, $label)
             . '</label>'
@@ -960,7 +960,7 @@ function defmodality()
     $GLOBALS['page']->add(
         Form::openFormLine()
             . Form::getInputRadio('order_type_random_category', 'order_type', 3, $order_type == 3, $script)
-            . '<label for="order_type_random_category">' . $lang->def('_ORDER_TYPE_CATEGORY') . '</label>'
+            . ' <label for="order_type_random_category">' . $lang->def('_ORDER_TYPE_CATEGORY') . '</label>'
             . $category_selector
             . Form::closeFormLine()
             . '<br />',


### PR DESCRIPTION
The radio alignment of those two options seems misaligned with the remaining labels, so this commit fixes it.
Before the fix:
<img width="1265" alt="SCR-20240117-mrko" src="https://github.com/formalms/formalms/assets/2974895/14fc5ab1-6af3-4fe3-a843-6c8a14191267">
After the fix:
<img width="1265" alt="SCR-20240117-mrpn" src="https://github.com/formalms/formalms/assets/2974895/5ca924bf-e692-4686-93bc-585fc2f85e2c">
