### PR TITLE
Fix HTML page title rendering (and possible other learning objects too)

### DIFF
--- a/html/appLms/class.module/track.object.php
+++ b/html/appLms/class.module/track.object.php
@@ -606,7 +606,7 @@ class Track_Object
 
     public function updateObjectTitle($idResource, $objectType, $new_title)
     {
-        // $new_title = str_replace('/', '', $new_title);
+        $new_title_no_slash = str_replace('/', '', $new_title);
 
         $re = true;
 
@@ -620,11 +620,11 @@ class Track_Object
         while (list($path) = sql_fetch_row($re_search)) {
             $path_piece = explode('/', $path);
             unset($path_piece[count($path_piece) - 1]);
-            $new_path = implode('/', $path_piece) . '/' . $new_title;
+            $new_path = implode('/', $path_piece) . '/' . $new_title_no_slash;
 
             $query_lo = '
 			UPDATE ' . $GLOBALS['prefix_lms'] . "_homerepo
-			SET path = '" . $new_path . "', title = '" . sql_escape_string($new_title) . "' 
+			SET path = '" . $new_path . "', title = '" . sql_escape_string($new_title_no_slash) . "' 
 			WHERE idResource = '" . (int) $idResource . "'  
 				AND objectType = '" . $objectType . "'";
             $re &= sql_query($query_lo);
@@ -647,11 +647,11 @@ class Track_Object
         while (list($path) = sql_fetch_row($re_search)) {
             $path_piece = explode('/', $path);
             unset($path_piece[count($path_piece) - 1]);
-            $new_path = implode('/', $path_piece) . '/' . $new_title;
+            $new_path = implode('/', $path_piece) . '/' . $new_title_no_slash;
 
             $query_lo = '
 			UPDATE ' . $GLOBALS['prefix_lms'] . "_repo
-			SET path = '" . $new_path . "', title = '" . sql_escape_string($new_title) . "' 
+			SET path = '" . $new_path . "', title = '" . sql_escape_string($new_title_no_slash) . "' 
 			WHERE idResource = '" . (int) $idResource . "'  
 				AND objectType = '" . $objectType . "'";
             $re &= sql_query($query_lo);

--- a/html/appLms/class.module/track.object.php
+++ b/html/appLms/class.module/track.object.php
@@ -606,7 +606,7 @@ class Track_Object
 
     public function updateObjectTitle($idResource, $objectType, $new_title)
     {
-        $new_title = str_replace('/', '', $new_title);
+        // $new_title = str_replace('/', '', $new_title);
 
         $re = true;
 
@@ -624,7 +624,7 @@ class Track_Object
 
             $query_lo = '
 			UPDATE ' . $GLOBALS['prefix_lms'] . "_homerepo
-			SET path = '" . $new_path . "', title = '" . $new_title . "' 
+			SET path = '" . $new_path . "', title = '" . sql_escape_string($new_title) . "' 
 			WHERE idResource = '" . (int) $idResource . "'  
 				AND objectType = '" . $objectType . "'";
             $re &= sql_query($query_lo);
@@ -632,7 +632,7 @@ class Track_Object
 
         $query_lo = '
 		UPDATE ' . $GLOBALS['prefix_lms'] . "_organization
-		SET title = '" . $new_title . "' 
+		SET title = '" . sql_escape_string($new_title) . "' 
 		WHERE idResource = '" . (int) $idResource . "'  
 			AND objectType = '" . $objectType . "'";
         $re &= sql_query($query_lo);
@@ -651,7 +651,7 @@ class Track_Object
 
             $query_lo = '
 			UPDATE ' . $GLOBALS['prefix_lms'] . "_repo
-			SET path = '" . $new_path . "', title = '" . $new_title . "' 
+			SET path = '" . $new_path . "', title = '" . sql_escape_string($new_title) . "' 
 			WHERE idResource = '" . (int) $idResource . "'  
 				AND objectType = '" . $objectType . "'";
             $re &= sql_query($query_lo);

--- a/html/appLms/modules/htmlpage/htmlpage.php
+++ b/html/appLms/modules/htmlpage/htmlpage.php
@@ -72,8 +72,8 @@ if (!Docebo::user()->isAnonymous()) {
 
         $insert_query = '
 	INSERT INTO ' . $GLOBALS['prefix_lms'] . "_htmlpage
-	SET title = '" . ((trim(addslashes($_REQUEST['title'])) == '') ? addslashes(Lang::t('_NOTITLE', 'htmlpage', 'lms')) : addslashes($_REQUEST['title'])) . "',
-		textof = '" . addslashes($_REQUEST['textof']) . "',
+	SET title = '" . ((trim(sql_escape_string($_REQUEST['title'])) == '') ? sql_escape_string(Lang::t('_NOTITLE', 'htmlpage', 'lms')) : sql_escape_string($_REQUEST['title'])) . "',
+		textof = '" . sql_escape_string($_REQUEST['textof']) . "',
 		author = '" . (int) getLogUserId() . "'";
         if (!sql_query($insert_query)) {
             Forma::addError(Lang::t('_OPERATION_FAILURE', 'htmlpage', 'lms'));
@@ -185,8 +185,8 @@ if (!Docebo::user()->isAnonymous()) {
 
         $insert_query = '
 	UPDATE ' . $GLOBALS['prefix_lms'] . "_htmlpage
-	SET title = '" . ((trim(addslashes($_REQUEST['title'])) == '') ? addslashes(Lang::t('_NOTITLE', 'htmlpage', 'lms')) : addslashes($_REQUEST['title'])) . "',
-		textof = '" . addslashes($_REQUEST['textof']) . "'
+	SET title = '" . ((trim(sql_escape_string($_REQUEST['title'])) == '') ? sql_escape_string(Lang::t('_NOTITLE', 'htmlpage', 'lms')) : sql_escape_string($_REQUEST['title'])) . "',
+		textof = '" . sql_escape_string($_REQUEST['textof']) . "'
 	WHERE idPage = '" . (int) $_REQUEST['idPage'] . "'";
         if (!sql_query($insert_query)) {
             Forma::addError(Lang::t('_OPERATION_FAILURE', 'htmlpage', 'lms'));


### PR DESCRIPTION
When creating a title with slashes (e.g. "Gravação de Aula - 08/01/2024"), the learning object was being saved with title "Gravação de Aula - 08012024" on the DB. This fixes ensures that slashes will be escaped and rendered as expected. For more information, please see https://forum.formalms.org/topic/14475.html