### PR TITLE
Check if variable is set before using it on lib.certificate

### DIFF
--- a/html/appLms/lib/lib.certificate.php
+++ b/html/appLms/lib/lib.certificate.php
@@ -364,7 +364,7 @@ class Certificate
             }
         }
 
-        if (isset($certificate[CERT_AV_POINT_REQUIRED]) && $course_score_final >= $certificate[CERT_AV_POINT_REQUIRED]) {
+        if (!isset($certificate[CERT_AV_POINT_REQUIRED]) || $course_score_final >= $certificate[CERT_AV_POINT_REQUIRED]) {
             return true;
         } else {
             return false;

--- a/html/appLms/lib/lib.certificate.php
+++ b/html/appLms/lib/lib.certificate.php
@@ -364,7 +364,7 @@ class Certificate
             }
         }
 
-        if ($course_score_final >= $certificate[CERT_AV_POINT_REQUIRED]) {
+        if (isset($certificate[CERT_AV_POINT_REQUIRED]) && $course_score_final >= $certificate[CERT_AV_POINT_REQUIRED]) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Avoid PHP warning error when upgrading FormaLMS from 3.3.22 to 3.3.24 with PHP directive "display_errors" set to On.