### PR TITLE
Check if variable is set before reading it in MycertificateLms.php

### DIFF
--- a/html/appLms/models/MycertificateLms.php
+++ b/html/appLms/models/MycertificateLms.php
@@ -63,7 +63,7 @@ class MycertificateLms extends Model
             }
         }
 
-        if ($order = $_REQUEST['order']) {
+        if (isset($_REQUEST['order']) && $order = $_REQUEST['order']) {
             $sort_index = $order[0]['column'];
 
             $fields = [


### PR DESCRIPTION
Avoid PHP Warning when upgrading FormaLMS 3.3.22 to 3.3.24 with PHP directive "Display errors" set to On.