### PR TITLE
Convert Learning_Cart to static to avoid PHP Fatal Error

### DIFF
--- a/html/appLms/lib/lib.cart.php
+++ b/html/appLms/lib/lib.cart.php
@@ -17,10 +17,10 @@ class Learning_Cart
 {
     public function __construct()
     {
-        Learning_Cart::istance();
+        Learning_Cart::init();
     }
 
-    public function init()
+    public static function init()
     {
         if (!SessionManager::getInstance()->getSession()->has('lms_cart')) {
             SessionManager::getInstance()->getSession()->set('lms_cart', []);
@@ -28,7 +28,7 @@ class Learning_Cart
         }
     }
 
-    public function cartItemCount()
+    public static function cartItemCount()
     {
         $count = 0;
         $cart = SessionManager::getInstance()->getSession()->get('lms_cart');
@@ -53,7 +53,7 @@ class Learning_Cart
         return $count;
     }
 
-    public function emptyCart()
+    public static function emptyCart()
     {
         SessionManager::getInstance()->getSession()->set('lms_cart', []);
         SessionManager::getInstance()->getSession()->save();


### PR DESCRIPTION
It's thrown a PHP Fatal Error because on ``getCart()`` function of /appLms/lib/LMSTemplateModel.php the ``Learning_Cart`` class is being called statically.