### PR TITLE
Convert UrlManager::getInstance to static to avoid PHP Fatal Error

### DIFF
--- a/html/lib/lib.urlmanager.php
+++ b/html/lib/lib.urlmanager.php
@@ -48,7 +48,7 @@ class UrlManager
         }
     }
 
-    public function &getInstance($param = false)
+    public static function &getInstance($param = false)
     {
         if ($param == false) {
             Log::add('used default urlamanager');


### PR DESCRIPTION
It's being called from ``lib.user_profile.php`` file as a static function so to avoid a PHP Fatal error it should be set to static.