### PR TITLE
Fix undefined GLOBAL variable during FormaLMS upgrade

### DIFF
--- a/html/lib/Get.php
+++ b/html/lib/Get.php
@@ -333,7 +333,7 @@ class Get
         } else {
             $platform = $item;
         }
-        $path = $GLOBALS['where_templates_relative'] . '/' . getTemplate() . '/';
+        $path = Get::cfg('where_templates_relative') . '/' . getTemplate() . '/';
 
         return str_replace('/./', '/', $path);
     }
@@ -404,7 +404,7 @@ class Get
     public static function link_img($url, $title, $src, $alt, $extra = false)
     {
         // where are we ?
-        $src = $GLOBALS['where_templates_relative'] . '/standard/images/' . $src;
+        $src = Get::cfg('where_templates_relative') . '/standard/images/' . $src;
 
         return '<a href="' . $url . '" title="' . $title . '"' .
             (!empty($extra['link']) != false ? ' ' . $extra['link'] : '') .

--- a/html/lib/Get.php
+++ b/html/lib/Get.php
@@ -333,7 +333,7 @@ class Get
         } else {
             $platform = $item;
         }
-        $path = Get::rel_path(_base_) . '/' . _folder_templates_ . '/' . getTemplate() . '/';
+        $path = self::rel_path(_base_) . '/' . _folder_templates_ . '/' . getTemplate() . '/';
 
         return str_replace('/./', '/', $path);
     }
@@ -404,7 +404,7 @@ class Get
     public static function link_img($url, $title, $src, $alt, $extra = false)
     {
         // where are we ?
-        $src = Get::rel_path(_base_) . '/' . _folder_templates_ . '/standard/images/' . $src;
+        $src = self::rel_path(_base_) . '/' . _folder_templates_ . '/standard/images/' . $src;
 
         return '<a href="' . $url . '" title="' . $title . '"' .
             (!empty($extra['link']) != false ? ' ' . $extra['link'] : '') .

--- a/html/lib/Get.php
+++ b/html/lib/Get.php
@@ -333,7 +333,7 @@ class Get
         } else {
             $platform = $item;
         }
-        $path = Get::rel_path(_base_) . '/templates/' . getTemplate() . '/';
+        $path = Get::rel_path(_base_) . '/' . _folder_templates_ . '/' . getTemplate() . '/';
 
         return str_replace('/./', '/', $path);
     }
@@ -404,7 +404,7 @@ class Get
     public static function link_img($url, $title, $src, $alt, $extra = false)
     {
         // where are we ?
-        $src = Get::rel_path(_base_) . '/templates/standard/images/' . $src;
+        $src = Get::rel_path(_base_) . '/' . _folder_templates_ . '/standard/images/' . $src;
 
         return '<a href="' . $url . '" title="' . $title . '"' .
             (!empty($extra['link']) != false ? ' ' . $extra['link'] : '') .

--- a/html/lib/Get.php
+++ b/html/lib/Get.php
@@ -333,7 +333,7 @@ class Get
         } else {
             $platform = $item;
         }
-                $path = Get::rel_path(_base_ . '/templates') . '/' . getTemplate() . '/';
+        $path = Get::rel_path(_base_ . '/templates') . '/' . getTemplate() . '/';
 
         return str_replace('/./', '/', $path);
     }

--- a/html/lib/Get.php
+++ b/html/lib/Get.php
@@ -333,7 +333,7 @@ class Get
         } else {
             $platform = $item;
         }
-        $path = Get::rel_path(_base_ . '/templates') . '/' . getTemplate() . '/';
+        $path = Get::rel_path(_base_) . '/templates/' . getTemplate() . '/';
 
         return str_replace('/./', '/', $path);
     }
@@ -404,7 +404,7 @@ class Get
     public static function link_img($url, $title, $src, $alt, $extra = false)
     {
         // where are we ?
-        $src = Get::rel_path(_base_ . '/templates') . '/standard/images/' . $src;
+        $src = Get::rel_path(_base_) . '/templates/standard/images/' . $src;
 
         return '<a href="' . $url . '" title="' . $title . '"' .
             (!empty($extra['link']) != false ? ' ' . $extra['link'] : '') .

--- a/html/lib/Get.php
+++ b/html/lib/Get.php
@@ -333,7 +333,7 @@ class Get
         } else {
             $platform = $item;
         }
-        $path = Get::cfg('where_templates_relative') . '/' . getTemplate() . '/';
+                $path = Get::rel_path(_base_ . '/templates') . '/' . getTemplate() . '/';
 
         return str_replace('/./', '/', $path);
     }
@@ -404,7 +404,7 @@ class Get
     public static function link_img($url, $title, $src, $alt, $extra = false)
     {
         // where are we ?
-        $src = Get::cfg('where_templates_relative') . '/standard/images/' . $src;
+        $src = Get::rel_path(_base_ . '/templates') . '/standard/images/' . $src;
 
         return '<a href="' . $url . '" title="' . $title . '"' .
             (!empty($extra['link']) != false ? ' ' . $extra['link'] : '') .


### PR DESCRIPTION
During stage 5 of upgrading from FormaLMS 3.3.22 to 3.3.24, the upgrade hangs and a PHP warning is thrown because "where_templates_relative" isn't set as a global variable without Boot class