### PR TITLE
Fix PHP undefined variable Warning during FormaLMS Upgrade

### DIFF
--- a/html/upgrade/upg_data.php
+++ b/html/upgrade/upg_data.php
@@ -58,7 +58,7 @@ if ($session->get('upgrade_ok')) {
     } else {
         $formalms_version = $GLOBALS['cfg']['versions'][$GLOBALS['cfg']['endversion']];
     }
-    $upgrade_msg .= ' <br/>' . 'Upgrading to version: ' . $formalms_version;
+    $upgrade_msg = ' <br/>' . 'Upgrading to version: ' . $formalms_version;
 
     // --- pre upgrade -----------------------------------------------------------
     $fn = _upgrader_ . '/data/upg_data/' . $GLOBALS['cfg']['detailversions'][$current_ver]['pre'];


### PR DESCRIPTION
``$upgrade_msg`` variable doesn't exist so it's throwing a PHP Warning when using concat during phase 5 of FormaLMS upgrade from 3.3.22 to 3.3.24 when accessing https://ava.example.com/upgrade/upg_data.php?cur_step=5&upg_step=1