### PR TITLE
Fix FormaLMS Upgrade script

### DIFF
--- a/html/upgrade/data/upg_data/10100_db.sql
+++ b/html/upgrade/data/upg_data/10100_db.sql
@@ -65,9 +65,22 @@ INSERT IGNORE INTO `learning_middlearea` (`obj_index`, `disabled`, `idst_list`, 
 
 -- -----------
 
-INSERT IGNORE INTO `learning_menu_under`
+-- Check if the table exists
+SELECT COUNT(*)
+INTO @table_exists
+FROM information_schema.tables 
+WHERE table_schema = DATABASE()
+AND table_name = 'learning_menu_under';
+
+-- Conditionally insert if the table exists
+SET @sql = IF(@table_exists > 0, "INSERT IGNORE INTO `learning_menu_under`
 (`idUnder`, `idMenu`, `module_name`, `default_name`, `default_op`, `associated_token`, `of_platform`, `sequence`, `class_file`, `class_name`, `mvc_path`) VALUES
-(8, 1, 'coursecategory', '_COURSECATEGORY', '', 'view', NULL, 4, '', '', 'alms/coursecategory/show');
+(8, 1, 'coursecategory', '_COURSECATEGORY', '', 'view', NULL, 4, '', '', 'alms/coursecategory/show');", 'SELECT "Table does not exist" AS Message;');
+
+-- Execute the SQL statement
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 INSERT IGNORE INTO `core_lang_text` (`id_text` ,`text_key` ,`text_module` ,`text_attributes`) VALUES (NULL , '_COURSECATEGORY', 'standard', '');
 

--- a/html/upgrade/data/upg_data/30323_db.sql
+++ b/html/upgrade/data/upg_data/30323_db.sql
@@ -1,9 +1,9 @@
 DELETE FROM learning_coursereport
                             WHERE id_report NOT IN (
-                                SELECT MIN(id_report) 
+                                SELECT * FROM (SELECT MIN(id_report) 
                                 FROM learning_coursereport 
                                 GROUP BY source_of, id_course, id_source
-                                );
+                                ) as t);
 DELETE FROM learning_coursereport
                             WHERE id_course = 0;
 DELETE FROM learning_coursereport_score

--- a/html/upgrade/data/upg_data/30323_db.sql
+++ b/html/upgrade/data/upg_data/30323_db.sql
@@ -21,7 +21,7 @@ INTO
 FROM
     `information_schema`.`statistics`
 WHERE
-    `table_schema` = 'my_database'
+    `table_schema` = DATABASE()
     AND `index_name` = 'unique_coursereport'
     AND `table_name` = 'learning_coursereport'
 ;

--- a/html/upgrade/data/upg_data/30323_db.sql
+++ b/html/upgrade/data/upg_data/30323_db.sql
@@ -13,11 +13,12 @@ DELETE FROM learning_coursereport_score
                               
                                 );
 
+ALTER TABLE learning_coursereport DROP INDEX unique_coursereport;
 
 ALTER TABLE learning_coursereport
         ADD CONSTRAINT unique_coursereport UNIQUE (source_of, id_course, id_source);
 
-INSERT INTO `core_setting` (`param_name`, `param_value`, `value_type`, `max_size`, `pack`, `regroup`, `sequence`, `param_load`, `hide_in_modify`, `extra_info`) VALUES
+INSERT IGNORE INTO `core_setting` (`param_name`, `param_value`, `value_type`, `max_size`, `pack`, `regroup`, `sequence`, `param_load`, `hide_in_modify`, `extra_info`) VALUES
                         ('force_scorm_finish', 'on', 'enum', 3, '0', 4, 17, 1, 0, '');
 
 /*repeated from former version for errors*/
@@ -31,7 +32,7 @@ CREATE TABLE IF NOT EXISTS learning_communication_lang (
 UPDATE `core_reg_setting` SET `value` = '-' WHERE `val_name` = 'date_sep';
 
 UPDATE core_menu_under SET module_name = 'dashboard' WHERE default_name = '_DASHBOARD' and associated_token = 'view' and of_platform = 'lms';
-INSERT INTO core_role ( idst, roleId )
+INSERT IGNORE INTO core_role ( idst, roleId )
 SELECT max(idst)+1, '/lms/course/public/dashboard/view' FROM core_st LIMIT 1;
 
 INSERT IGNORE INTO `core_menu` ( `name`, `image`, `sequence`, `is_active`, `collapse`, `idParent`, `idPlugin`, `of_platform` )

--- a/html/upgrade/data/upg_data/30323_db.sql
+++ b/html/upgrade/data/upg_data/30323_db.sql
@@ -14,19 +14,14 @@ DELETE FROM learning_coursereport_score
                                 );
 
 -- DROP INDEX IF EXISTS
-SELECT
-    COUNT(*)
-INTO
-    @INDEX_my_index_ON_TABLE_my_table_EXISTS
-FROM
-    `information_schema`.`statistics`
-WHERE
-    `table_schema` = DATABASE()
-    AND `index_name` = 'unique_coursereport'
-    AND `table_name` = 'learning_coursereport'
-;
+SELECT COUNT(*) AS index_exists
+FROM information_schema.STATISTICS
+WHERE table_schema = DATABASE()
+  AND table_name = 'learning_coursereport'
+  AND index_name = 'unique_coursereport';
+
 SET @statement := IF(
-    @INDEX_my_index_ON_TABLE_my_table_EXISTS > 0,
+    @index_exists > 0,
     -- 'SELECT "info: index exists."',
     'DROP INDEX `unique_coursereport` ON `learning_coursereport`',
     'SELECT "info: index does not exist."'

--- a/html/upgrade/data/upg_data/30323_db.sql
+++ b/html/upgrade/data/upg_data/30323_db.sql
@@ -13,7 +13,27 @@ DELETE FROM learning_coursereport_score
                               
                                 );
 
-ALTER TABLE learning_coursereport DROP INDEX unique_coursereport;
+-- DROP INDEX IF EXISTS
+SELECT
+    COUNT(*)
+INTO
+    @INDEX_my_index_ON_TABLE_my_table_EXISTS
+FROM
+    `information_schema`.`statistics`
+WHERE
+    `table_schema` = 'my_database'
+    AND `index_name` = 'unique_coursereport'
+    AND `table_name` = 'learning_coursereport'
+;
+SET @statement := IF(
+    @INDEX_my_index_ON_TABLE_my_table_EXISTS > 0,
+    -- 'SELECT "info: index exists."',
+    'DROP INDEX `unique_coursereport` ON `learning_coursereport`',
+    'SELECT "info: index does not exist."'
+);
+PREPARE statement FROM @statement;
+EXECUTE statement;
+DEALLOCATE PREPARE statement;
 
 ALTER TABLE learning_coursereport
         ADD CONSTRAINT unique_coursereport UNIQUE (source_of, id_course, id_source);

--- a/html/upgrade/data/upg_data/30323_db.sql
+++ b/html/upgrade/data/upg_data/30323_db.sql
@@ -13,25 +13,31 @@ DELETE FROM learning_coursereport_score
                               
                                 );
 
--- DROP INDEX IF EXISTS
-SELECT COUNT(*) AS index_exists
-FROM information_schema.STATISTICS
-WHERE table_schema = DATABASE()
-  AND table_name = 'learning_coursereport'
-  AND index_name = 'unique_coursereport';
+-- Variables for table and constraint
+SET @table_name = DATABASE();
+SET @table_name = 'learning_coursereport';
+SET @constraint_name = 'unique_coursereport';
 
-SET @statement := IF(
-    @index_exists > 0,
-    -- 'SELECT "info: index exists."',
-    'DROP INDEX `unique_coursereport` ON `learning_coursereport`',
-    'SELECT "info: index does not exist."'
+-- Check if the constraint already exists
+SET @constraint_exists = (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_TYPE = 'UNIQUE'
+      AND TABLE_NAME = @table_name
+      AND CONSTRAINT_NAME = @constraint_name
 );
-PREPARE statement FROM @statement;
-EXECUTE statement;
-DEALLOCATE PREPARE statement;
 
-ALTER TABLE learning_coursereport
-        ADD CONSTRAINT unique_coursereport UNIQUE (source_of, id_course, id_source);
+-- Conditionally add the constraint if it does not exist
+SET @sql = IF(
+    @constraint_exists = 0,
+    CONCAT('ALTER TABLE ', @table_name, ' ADD CONSTRAINT ', @constraint_name, ' UNIQUE (source_of, id_course, id_source);'),
+    'SELECT "Constraint already exists.";'
+);
+
+-- Execute the SQL
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 INSERT IGNORE INTO `core_setting` (`param_name`, `param_value`, `value_type`, `max_size`, `pack`, `regroup`, `sequence`, `param_load`, `hide_in_modify`, `extra_info`) VALUES
                         ('force_scorm_finish', 'on', 'enum', 3, '0', 4, 17, 1, 0, '');
@@ -50,26 +56,42 @@ UPDATE core_menu_under SET module_name = 'dashboard' WHERE default_name = '_DASH
 INSERT IGNORE INTO core_role ( idst, roleId )
 SELECT max(idst)+1, '/lms/course/public/dashboard/view' FROM core_st LIMIT 1;
 
-INSERT IGNORE INTO `core_menu` ( `name`, `image`, `sequence`, `is_active`, `collapse`, `idParent`, `idPlugin`, `of_platform` )
-VALUES
-    ( '_MANAGEMENT_COMMUNICATION', '', '4', TRUE, TRUE, (SELECT `idMenu` FROM ( SELECT `idMenu` FROM `core_menu` WHERE NAME = '_CONTENTS' LIMIT 1 ) tbl), NULL, 'framework' );
+SET @idParent = ( SELECT `idMenu` FROM `core_menu` WHERE `name` = '_CONTENTS' LIMIT 1 );
+INSERT INTO `core_menu` ( `name`, `image`, `sequence`, `is_active`, `collapse`, `idParent`, `idPlugin`, `of_platform` )
+SELECT * FROM (
+    SELECT '_MANAGEMENT_COMMUNICATION', '', '4', TRUE AS `true1`, TRUE AS `true2`, @idParent, NULL, 'framework' 
+ ) AS tmp
+WHERE NOT EXISTS (
+    SELECT 'idParent' FROM `core_menu`
+        WHERE `name` = '_MANAGEMENT_COMMUNICATION'
+) LIMIT 1;
 
-INSERT IGNORE INTO `core_menu` ( `name`, `image`, `sequence`, `is_active`, `collapse`, `idParent`, `idPlugin`, `of_platform` )
-VALUES
-    ( '_CATEGORIES', '', '1', TRUE, TRUE, (SELECT `idMenu` FROM ( SELECT `idMenu` FROM `core_menu` WHERE NAME = '_MANAGEMENT_COMMUNICATION' ) tbl), NULL, 'framework' );
+SET @idParent = ( SELECT `idMenu` FROM `core_menu` WHERE NAME = '_MANAGEMENT_COMMUNICATION' LIMIT 1 );
+INSERT INTO `core_menu` ( `name`, `image`, `sequence`, `is_active`, `collapse`, `idParent`, `idPlugin`, `of_platform` )
+SELECT * FROM (
+    SELECT '_CATEGORIES', '', '1', TRUE AS `true1`, TRUE AS `true2`, @idParent, NULL, 'framework' 
+ ) AS tmp
+WHERE NOT EXISTS (
+    SELECT 'idParent' FROM `core_menu`
+        WHERE `name` = '_CATEGORIES'
+) LIMIT 1;
 
 UPDATE `core_menu` SET `idParent` =  (SELECT `idMenu` FROM ( SELECT `idMenu` FROM `core_menu` WHERE NAME = '_MANAGEMENT_COMMUNICATION' LIMIT 1) tbl) WHERE name = '_COMMUNICATION_MAN';
 
-INSERT IGNORE INTO `core_menu_under` ( `idMenu`, `module_name`, `default_name`, `default_op`, `associated_token`, `of_platform`, `sequence`, `class_file`, `class_name`, `mvc_path` )
-VALUES
-    ( ( SELECT `idMenu` FROM `core_menu` WHERE NAME = '_CATEGORIES' LIMIT 1 ) ,
+SET @idMenu = ( SELECT `idMenu` FROM `core_menu` WHERE `name` = '_CATEGORIES' LIMIT 1 );
+INSERT INTO `core_menu_under` ( `idMenu`, `module_name`, `default_name`, `default_op`, `associated_token`, `of_platform`, `sequence`, `class_file`, `class_name`, `mvc_path` )
+SELECT * FROM (SELECT @idMenu,
     'communication',
     '_CATEGORIES',
-    NULL,
+    NULL AS `null1`,
     'view',
     'framework',
     1,
-    NULL,
-    NULL,
+    NULL AS `null2`,
+    NULL AS `null3`,
     'alms/communication/showCategories'
-    );
+    ) AS tmp
+WHERE NOT EXISTS (
+    SELECT `idMenu` FROM `core_menu_under`
+        WHERE `idMenu` = @idMenu
+) LIMIT 1;


### PR DESCRIPTION
Unable to upgrade from FormaLMS 3.3.22 to 3.3.24 as the MySQL error is thrown:

```
Fatal error: Uncaught mysqli_sql_exception: You can't specify target table 'learning_coursereport' for update in FROM clause in /home/robertinho/public_html/ava.example.com/db/drivers/docebodb.mysqli.php:127 Stack trace: #0 /home/robertinho/public_html/ava.example.com/db/drivers/docebodb.mysqli.php(127): mysqli_query(Object(mysqli), 'DELETE FROM lea...') #1 /home/robertinho/public_html/ava.example.com/db/lib.docebodb.php(522): mysqli_DbConn->query('DELETE FROM lea...') #2 /home/robertinho/public_html/ava.example.com/lib/installer/lib.php(111): sql_query('DELETE FROM lea...') #3 /home/robertinho/public_html/ava.example.com/upgrade/upg_data.php(86): importSqlFile('/home/robertinh...', Array) #4 {main} thrown in /home/robertinho/public_html/ava.example.com/db/drivers/docebodb.mysqli.php on line 127
```

This fix also allows this MySQL SQL file be runned twice (e.g. if upgrade fails it can be attempted again).